### PR TITLE
Wrap long lines in changelog entries: 1:3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ unrar-nonfree (1:5.6.6-3) UNRELEASED; urgency=medium
   * Trim trailing whitespace.
   * Bump debhelper from old 9 to 12.
   * Set debhelper-compat version in Build-Depends.
+  * Wrap long lines in changelog entries: 1:3.6.8-0ubuntu2.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 24 Dec 2019 02:53:57 +0000
 
@@ -210,7 +211,8 @@ unrar-nonfree (1:3.5.4-1) unstable; urgency=low
 
 unrar-nonfree (1:3.6.8-0ubuntu2) feisty; urgency=low
 
-  * Fix Maintainer Field to currect maintainer (1:3.5.4-1 was not synced from debian)
+  * Fix Maintainer Field to currect maintainer (1:3.5.4-1 was not synced from
+    debian)
 
  -- Martin Meredith <mez@ubuntu.com>  Tue,  7 Nov 2006 16:41:45 +0000
 


### PR DESCRIPTION
Wrap long lines in changelog entries: 1:3.6.8-0ubuntu2. ([debian-changelog-line-too-long](https://lintian.debian.org/tags/debian-changelog-line-too-long.html))

This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/unrar-nonfree/64a704eb-64e6-43ef-a923-f080581a34e1.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/64a704eb-64e6-43ef-a923-f080581a34e1/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/64a704eb-64e6-43ef-a923-f080581a34e1/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/64a704eb-64e6-43ef-a923-f080581a34e1/diffoscope)).
