### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,6 @@ Package: unrar
 Architecture: any
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Breaks: rar (<= 2.60-1)
 Description: Unarchiver for .rar files (non-free version)
  Unrar can extract files from .rar archives. If you want to create .rar
  archives, install package rar.


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/unrar-nonfree/c0491616-8408-422e-9a52-3d06679b60a3.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)

No differences were encountered between the control files of package \*\*libunrar-dev\*\*

No differences were encountered between the control files of package \*\*libunrar-headers\*\*

No differences were encountered between the control files of package \*\*libunrar5\*\*

No differences were encountered between the control files of package \*\*libunrar5-dbgsym\*\*
### Control files of package unrar: lines which differ (wdiff format)
* [-Breaks: rar (<= 2.60-1)-]

No differences were encountered between the control files of package \*\*unrar-dbgsym\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/c0491616-8408-422e-9a52-3d06679b60a3/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/c0491616-8408-422e-9a52-3d06679b60a3/diffoscope)).
